### PR TITLE
For better precision, now extract Pull Request list from commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ program
           'for private repos or if you want to bypass the Github API limit rate).')
     .option('-s, --since <iso-date>', 'Initial date or commit sha (required).')
     .option('--until <iso-date>', 'Limit date or commit sha.')
-    .option('-m, --merged', 'List merged pull requests only.')
     .option('-t, --template <path>', 'EJS template to format data.' +
         'The default bundled template generates a list of issues in Markdown')
     .option('-g, --gist', 'Publish output to a Github gist.')
@@ -237,10 +236,6 @@ function streamDateFromDateStringOrCommitId(dateStringOrCommitId) {
     });
 }
 
-function pullRequestIsMerged(pullRequest) {
-  return pullRequest.merged_at !== null;
-}
-
 function commitIsMergedPullRequest(commit) {
   return commit.parents.length > 1;
 }
@@ -278,11 +273,6 @@ var pullRequests = params
 // // Get a stream providing the pull requests.
 // var pullRequests = params
 //   .flatMap(streamAllPullRequestsBetween);
-//
-// // Keep only merged pull requests if specified.
-// if (program.merged) {
-//   pullRequests = pullRequests.filter(pullRequestIsMerged);
-// }
 
 // Generate changelog text.
 var changelog = Bacon

--- a/index.js
+++ b/index.js
@@ -107,7 +107,6 @@ function paginator(pageStreamCallback, stopCondition) {
   var paginationNeeded = true;
 
   return Bacon.repeat(function(index) {
-
     if (!paginationNeeded) {
       return false;
     }
@@ -200,6 +199,10 @@ function streamDateFromDateStringOrCommitId(dateStringOrCommitId) {
     });
 }
 
+function pullRequestIsMerged(pullRequest) {
+  return pullRequest.merged_at !== null;
+}
+
 
 var sinceDateStream = streamDateFromDateStringOrCommitId(program.since);
 var untilDateStream = streamDateFromDateStringOrCommitId(program.until);
@@ -213,9 +216,7 @@ var pullRequests = params
 
 // Keep only merged pull requests if specified.
 if (program.merged) {
-  pullRequests = pullRequests.filter(function(pullRequest) {
-    return pullRequest.merged_at !== null;
-  });
+  pullRequests = pullRequests.filter(pullRequestIsMerged);
 }
 
 // Generate changelog text.

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function pullRequestIsMerged(pullRequest) {
   return pullRequest.merged_at !== null;
 }
 
-function commitIsPullRequestMergeCommit(commit) {
+function commitIsMergedPullRequest(commit) {
   return commit.parents.length > 1;
 }
 
@@ -270,7 +270,7 @@ var params = Bacon
 // Get a stream of pull request ids, based on merged commits between since and until.
 var pullRequests = params
   .flatMap(retrieveCommits)
-  .filter(commitIsPullRequestMergeCommit)
+  .filter(commitIsMergedPullRequest)
   .flatMap(getPullRequestIdFromCommit)
   .flatMap(retrievePullRequestById)
   ;

--- a/index.js
+++ b/index.js
@@ -267,14 +267,22 @@ var untilDateStream = streamDateFromDateStringOrCommitId(program.until);
 var params = Bacon
   .combineTemplate({ since: sinceDateStream, until: untilDateStream });
 
-// Get a stream providing the pull requests.
+// Get a stream of pull request ids, based on merged commits between since and until.
 var pullRequests = params
-  .flatMap(streamAllPullRequestsBetween);
+  .flatMap(retrieveCommits)
+  .filter(commitIsPullRequestMergeCommit)
+  .flatMap(getPullRequestIdFromCommit)
+  .flatMap(retrievePullRequestById)
+  ;
 
-// Keep only merged pull requests if specified.
-if (program.merged) {
-  pullRequests = pullRequests.filter(pullRequestIsMerged);
-}
+// // Get a stream providing the pull requests.
+// var pullRequests = params
+//   .flatMap(streamAllPullRequestsBetween);
+//
+// // Keep only merged pull requests if specified.
+// if (program.merged) {
+//   pullRequests = pullRequests.filter(pullRequestIsMerged);
+// }
 
 // Generate changelog text.
 var changelog = Bacon

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "github": "0.2.4",
     "commander": "2.2.0",
     "ejs": "2.3.4",
-    "baconjs": "0.7.73"
+    "baconjs": "0.7.73",
+    "not": "0.1.0"
   },
   "bin": {
     "gh-changelog": "./index.js"


### PR DESCRIPTION
**Before**: retrieve Pull Requests by closed status between 2 dates.
**After**: retrieve Pull Requests from the list of commits between 2 commits.

=> this fixes the possibly wrong Pull Requests that were retrieved when starting from a commit belonging to an open Pull Request (i.e. from a branch other than `master`)